### PR TITLE
FIX: name in start and stop are misaligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export DEEPL_PROXY_URL=http://localhost:3001
 
 When finished, stop the Docker container:
 ```shell
-docker stop deepl/deepl-mock
+docker stop deepl-mock
 ```
 
 ### Manually


### PR DESCRIPTION
In the README, the container is started with `--name deepl-mock`. However, the container is stopped with name 'deepl/deepl-mock' leading to an cli error message of "No such container: deepl/deepl-mock".

In order to correct this misalignment, the docker stop command should be changed to stop the container with name 'deepl-mock'.
Changing the name to 'deepl/deepl-mock' is not possible, due to the character '/' not allowed in docker container names.